### PR TITLE
Remove dependency on Huey

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Storage](https://edgeguides.rubyonrails.org/active_storage_overview.html).
 
 ### Future work
 
-- [ ] Reduce number of dependencies:
-    - [ ] Make Huey dependency optional
-    - [ ] Make PIL dependency optional
 - [ ] Remove dependency on `base58`
 - [ ] Implement private file links (maybe via signed URLs?)
+- [ ] Support for async/delayed variant generation
+- [ ] Reduce number of dependencies:
+    - [ ] Make PIL dependency optional
 
 ## Installation
 

--- a/anchor/models/fields.py
+++ b/anchor/models/fields.py
@@ -9,7 +9,6 @@ from django.db import models
 from django.db.models.fields.files import FieldFile, FileField
 from django.utils.functional import cached_property
 
-from anchor.tasks import blob_make_variant
 
 DEFAULT_CONTENT_TYPE = "application/octet-stream"
 
@@ -41,8 +40,9 @@ class VariantFieldFile(FieldFile):
 
         if blocking:
             return self.make_variant(variant_name, format_params)
-
-        blob_make_variant(self, variant_name, format_params)
+        else:
+            # TODO: implement async variant generation
+            return self.make_variant(variant_name, format_params)
 
     def get_variant_url(self, fallback=False, blocking=False, **format_params):
         """

--- a/anchor/tasks.py
+++ b/anchor/tasks.py
@@ -1,6 +1,0 @@
-from huey.contrib.djhuey import task
-
-
-@task()
-def blob_make_variant(blob, variant_name, format_params):
-    blob.make_variant(variant_name, format_params)

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -108,7 +108,3 @@ MEDIA_URL = "/media/"
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
-HUEY = {
-    "immediate": True,
-}

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,17 +29,6 @@ typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
-name = "async-timeout"
-version = "4.0.3"
-description = "Timeout context manager for asyncio programs"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
-    {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
-]
-
-[[package]]
 name = "babel"
 version = "2.15.0"
 description = "Internationalization utilities"
@@ -320,20 +309,6 @@ files = [
 docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
 testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-asyncio (>=0.21)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)", "virtualenv (>=20.26.2)"]
 typing = ["typing-extensions (>=4.8)"]
-
-[[package]]
-name = "huey"
-version = "2.5.1"
-description = "huey, a little task queue"
-optional = false
-python-versions = "*"
-files = [
-    {file = "huey-2.5.1.tar.gz", hash = "sha256:8a323783ab434a095a4e72b8c48c5b8f957f9031fa860474a390a0927e957112"},
-]
-
-[package.extras]
-backends = ["redis (>=3.0.0)"]
-redis = ["redis (>=3.0.0)"]
 
 [[package]]
 name = "identify"
@@ -685,24 +660,6 @@ files = [
 ]
 
 [[package]]
-name = "redis"
-version = "5.0.7"
-description = "Python client for Redis database and key-value store"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "redis-5.0.7-py3-none-any.whl", hash = "sha256:0e479e24da960c690be5d9b96d21f7b918a98c0cf49af3b6fafaa0753f93a0db"},
-    {file = "redis-5.0.7.tar.gz", hash = "sha256:8f611490b93c8109b50adc317b31bfd84fff31def3475b92e7e80bf39f48175b"},
-]
-
-[package.dependencies]
-async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\""}
-
-[package.extras]
-hiredis = ["hiredis (>=1.0.0)"]
-ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
-
-[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -962,4 +919,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "e46b82f8580115cce04a7eb2c74ba89b3da4193c6a7dec251117ef8a57fd1cb7"
+content-hash = "a35c8f0ae6b169f489f06d1f8c07e362eeef48c10e1ec14424fdbc6dca2c7cbe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Operating System :: OS Independent",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Topic :: File Formats",
@@ -27,9 +28,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.10,<4"
 django = ">=4.2,<6"
-huey = "^2.5.1"
 base58 = "^2.1.1"
-redis = "^5.0.7"
 pillow = "^10.4.0"
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -34,7 +34,3 @@ TIME_ZONE = "UTC"
 
 MEDIA_ROOT = os.path.join("tmp")
 STATIC_ROOT = os.path.join("tmp")
-
-HUEY = {
-    "immediate": True,
-}


### PR DESCRIPTION
For now, we'll not have async variant generation, until I implement a framework agnostic way to do it or something that's compatible with multiple background job frameworks.