### PR TITLE
Update uv to 0.10.2 in CI workflows

### DIFF
--- a/.github/workflows/compatibility_test.yml
+++ b/.github/workflows/compatibility_test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install UV
         run: |
-          python -m pip install uv==0.5.8
+          python -m pip install uv==0.10.2
 
       - name: Install dependencies
         run: |
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install UV
         run: |
-          python -m pip install uv==0.5.8
+          python -m pip install uv==0.10.2
 
       - name: Install dependencies
         run: |
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install UV
         run: |
-          python -m pip install uv==0.5.8
+          python -m pip install uv==0.10.2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Install UV
         run: |
-          python -m pip install uv==0.5.8
+          python -m pip install uv==0.10.2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install UV
         run: |
-          python -m pip install uv==0.5.8
+          python -m pip install uv==0.10.2
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

- Updates `uv` from `0.5.8` to `0.10.2` in all three CI workflows (`test.yml`, `compatibility_test.yml`, `publish_to_pypi.yml`)

The `uv.lock` is now generated by uv 0.10.2 (pinned in `.tool-versions`). The newer lock file format includes fields like `upload-time` that uv 0.5.8 cannot parse, causing this error in all workflow runs:

```
error: Failed to parse `uv.lock`
  Caused by: TOML parse error at line 216, column 1
missing field `version`
```

## Test plan

- [x] Verify the Test workflow passes on this PR
- [x] Verify the Compatibility Test workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)