### PR TITLE
Fix Blob.backend overwritten when loading from DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.8.1 - 2026-03-10
+
+**Fixed:**
+
+- Fixed a bug where `Blob.__init__` silently overwrote the `backend` field with
+  the default value every time a Blob was loaded from the database. This caused
+  blobs stored on non-default backends (e.g. a private documents backend) to
+  generate URLs using the default backend's configuration, resulting in incorrect
+  hostnames and unsigned URLs.
+
 ## v0.8.0 - 2026-03-04
 
 **Fixed:**

--- a/anchor/__init__.py
+++ b/anchor/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 8, 0)
+VERSION = (0, 8, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/anchor/models/blob/blob.py
+++ b/anchor/models/blob/blob.py
@@ -140,15 +140,12 @@ class Blob(KeysMixin, RepresentationsMixin, BaseModel):
     If you need to store custom metadata, refer to the :py:attr:`custom_metadata` property.
     """
 
-    def __init__(self, *args, backend=None, **kwargs):
+    def __init__(self, *args, **kwargs):
+        if not args and not kwargs.get("backend"):
+            kwargs["backend"] = anchor_settings.DEFAULT_STORAGE_BACKEND
         super().__init__(*args, **kwargs)
         if self.key == "":
             self.key = type(self).generate_key()
-
-        if backend is not None:
-            self.backend = backend
-        else:
-            self.backend = anchor_settings.DEFAULT_STORAGE_BACKEND
 
     @property
     def signed_id(self):

--- a/tests/models/blob/test_blob.py
+++ b/tests/models/blob/test_blob.py
@@ -168,6 +168,22 @@ class TestBlobURLs(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
 
 
+class TestBlobBackend(TestCase):
+    def test_backend_is_preserved_after_loading_from_db(self):
+        blob = Blob.objects.create(filename="test.png", backend="documents")
+        blob.refresh_from_db()
+        self.assertEqual(blob.backend, "documents")
+
+    def test_backend_is_preserved_when_fetched_from_queryset(self):
+        blob = Blob.objects.create(filename="test.png", backend="documents")
+        fetched = Blob.objects.get(pk=blob.pk)
+        self.assertEqual(fetched.backend, "documents")
+
+    def test_backend_defaults_to_default_for_new_blobs(self):
+        blob = Blob()
+        self.assertEqual(blob.backend, anchor_settings.DEFAULT_STORAGE_BACKEND)
+
+
 class TestBlobQuerySet(TestCase):
     def test_get_signed(self):
         blob = Blob.objects.create(filename="test.png")


### PR DESCRIPTION
## Summary

- `Blob.__init__` intercepted the `backend` kwarg and unconditionally set it to the default when `None` was passed. Since Django's `Model.from_db()` passes DB values as positional args, the keyword parameter was always `None` on load — silently resetting every blob's backend to `"default"`.
- This caused blobs on non-default backends (e.g. a private documents bucket) to generate URLs using the wrong storage configuration, producing incorrect hostnames and unsigned URLs.
- The fix lets `backend` flow through to `Model.__init__` normally and only applies the configurable default for genuinely new instances (no positional args and no backend kwarg).

## Test plan

- [x] Added regression tests for backend preservation after `refresh_from_db()` and `objects.get()`
- [x] Added test that new blobs still get the default backend
- [x] All 118 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)