### PR TITLE
Fix docs build: align .readthedocs.yaml versions with .tool-versions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,11 +3,11 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.13"
+    python: "3.14"
   commands:
     - asdf plugin add uv
-    - asdf install uv 0.5.13
-    - asdf global uv 0.5.13
-    - asdf local python 3.13.3
+    - asdf install uv 0.10.2
+    - asdf global uv 0.10.2
+    - asdf local python 3.14.3
     - uv sync --all-groups --frozen
     - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
## Summary

- Bump Python from `3.13` / `3.13.3` to `3.14` / `3.14.3`
- Bump uv from `0.5.13` to `0.10.2`

Both now match the versions specified in `.tool-versions`, fixing the failing ReadTheDocs build.

## Test plan

- [ ] Verify the ReadTheDocs build passes after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)