### PR TITLE
Fix docs build: align versions and explicitly install Python 3.14.3

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,7 @@ build:
     - asdf plugin add uv
     - asdf install uv 0.10.2
     - asdf global uv 0.10.2
+    - asdf install python 3.14.3
     - asdf local python 3.14.3
     - uv sync --all-groups --frozen
     - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
## Summary

- Bump Python from `3.13` / `3.13.3` to `3.14` / `3.14.3` to match `.tool-versions`
- Bump uv from `0.5.13` to `0.10.2` to match `.tool-versions`
- Add `asdf install python 3.14.3` before `asdf local python 3.14.3`

The `tools.python: "3.14"` field only installs the latest 3.14.x patch available to ReadTheDocs, which may not be `3.14.3`. Without an explicit `asdf install`, the `asdf local` command fails with *version 3.14.3 is not installed for python*.

## Test plan

- [ ] Verify the ReadTheDocs build passes after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)